### PR TITLE
feat: omit an option by throwing an event

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -553,6 +553,7 @@ export default {
     /**
      * User defined function for adding Options
      * @type {Function}
+     * @throws {Error} throw error to omit an option
      */
     createOption: {
       type: Function,
@@ -974,9 +975,13 @@ export default {
         ? this.filter(optionList, this.search, this)
         : optionList
       if (this.taggable && this.search.length) {
-        const createdOption = this.createOption(this.search)
-        if (!this.optionExists(createdOption)) {
-          options.unshift(createdOption)
+        try {
+          const createdOption = this.createOption(this.search)
+          if (!this.optionExists(createdOption)) {
+            options.unshift(createdOption)
+          }
+        } catch (e) {
+          // omit option on error
         }
       }
       return limitOptions(options)

--- a/tests/unit/CreateOption.spec.js
+++ b/tests/unit/CreateOption.spec.js
@@ -27,4 +27,27 @@ describe('CreateOption When Tagging Is Enabled', () => {
 
     expect(Select.emitted('input')[0]).toEqual([{ name: 'two' }])
   })
+
+  it('omit option when throwing an error', async () => {
+    const Select = selectWithProps({
+      taggable: true,
+      multiple: false,
+      value: null,
+      options: [],
+      label: 'name',
+      createOption: function (value) {
+        if (value.includes('@')) {
+          return { name: value }
+        }
+
+        throw new Error('value does not include an @')
+      },
+    })
+
+    await selectTag(Select, 'bob')
+    expect(Select.emitted('input')).toBeUndefined()
+
+    await selectTag(Select, 'bob@example.org')
+    expect(Select.emitted('input')[0]).toEqual([{ name: 'bob@example.org' }])
+  })
 })


### PR DESCRIPTION
The mail app uses NcSelect for selecting email recipients, so we would like to validate the input in the createOption callback to ensure only valid email addresses are added as options.

The upstream issue https://github.com/sagalbot/vue-select/issues/1687 suggested throwing an exception rather than filtering out null or undefined because one might want to use them as values. While I'm not so sure about a potential use case for that, it sounded still reasonable to throw.