### PR TITLE
fix(a11y): don't auto-open dropdown on focus, hide decorative chevron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### 🐛 Fixed bugs
+* fix(a11y): do not auto-open the dropdown on search input focus (WCAG 3.2.1 *On Focus*). Keyboard users still open via Space/Enter/ArrowDown/ArrowUp; mouse users still open by clicking.
+* fix(a11y): hide the decorative open-indicator button from the accessibility tree (`aria-hidden="true"`, no `aria-labelledby`/`aria-controls`/`aria-expanded`). WCAG 4.1.2 *Name, Role, Value*.
+
+### ⚠️ Behavior changes
+* Focusing the combobox no longer opens the dropdown. Consumers that relied on this side-effect should open the dropdown explicitly (e.g. via `ref.open = true`) or migrate to a keyboard/click gesture.
+* The open-indicator button no longer exposes its listbox state to assistive technology. Any code querying those ARIA attributes on `.vs__open-indicator-button` will need to update.
+
 ## [4.0.0](https://github.com/nextcloud-libraries/vue-select/compare/v3.26.0...v4.0.0) (2026-04-01)
 
 ### ⚠️ Breaking Changes

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -60,16 +60,14 @@
 					<component :is="childComponents.Deselect" />
 				</button>
 
-				<!-- tabindex -1 is used to remove it from the tab sequence as tabbing to the input combobox opens the dropdown -->
+				<!-- Decorative: keyboard users reach the combobox input directly, which already exposes the open/close state. -->
 				<button
 					v-if="!noDrop"
 					ref="openIndicatorButton"
 					class="vs__open-indicator-button"
 					type="button"
 					tabindex="-1"
-					:aria-labelledby="`vs-${uid}__listbox`"
-					:aria-controls="`vs-${uid}__listbox`"
-					:aria-expanded="dropdownOpen.toString()"
+					aria-hidden="true"
 					@mousedown="toggleDropdown">
 					<slot name="open-indicator" v-bind="scope.openIndicator">
 						<component
@@ -1494,13 +1492,14 @@ export default {
 		},
 
 		/**
-		 * Open the dropdown on focus.
+		 * Do NOT open the dropdown here: auto-opening on focus violates
+		 * WCAG 3.2.1 (On Focus). Keyboard users open via
+		 * Space/Enter/ArrowDown/ArrowUp; mouse users click.
 		 *
 		 * @fires  {search:focus}
 		 * @return {void}
 		 */
 		onSearchFocus() {
-			this.open = true
 			this.$emit('search:focus')
 		},
 

--- a/tests/unit/Accessibility.spec.js
+++ b/tests/unit/Accessibility.spec.js
@@ -82,6 +82,22 @@ describe('Open Indicator', () => {
 		expect(button.attributes('tabindex')).toEqual('-1')
 	})
 
+	it('is hidden from the accessibility tree via aria-hidden', () => {
+		const Select = mountDefault()
+		const button = Select.get({ ref: 'openIndicatorButton' })
+
+		expect(button.attributes('aria-hidden')).toEqual('true')
+	})
+
+	it('exposes no aria-labelledby, aria-controls, or aria-expanded so screen readers ignore it', () => {
+		const Select = mountDefault()
+		const button = Select.get({ ref: 'openIndicatorButton' })
+
+		expect(button.attributes('aria-labelledby')).toBeUndefined()
+		expect(button.attributes('aria-controls')).toBeUndefined()
+		expect(button.attributes('aria-expanded')).toBeUndefined()
+	})
+
 	it('toggle with mouse', async () => {
 		const Select = mountDefault()
 		const button = Select.get({ ref: 'openIndicatorButton' })
@@ -90,6 +106,26 @@ describe('Open Indicator', () => {
 		expect(Select.vm.open).toEqual(true)
 		await button.trigger('mousedown')
 		expect(Select.vm.open).toEqual(false)
+	})
+})
+
+describe('Focus behavior', () => {
+	it('focusing the search input does not auto-open the dropdown (WCAG 3.2.1)', async () => {
+		const Select = mountDefault()
+
+		Select.vm.onSearchFocus()
+		await nextTick()
+
+		expect(Select.vm.open).toEqual(false)
+	})
+
+	it('still emits the search:focus event when the search input is focused', async () => {
+		const Select = mountDefault()
+
+		Select.vm.onSearchFocus()
+		await nextTick()
+
+		expect(Select.emitted('search:focus')).toBeTruthy()
 	})
 })
 

--- a/tests/unit/Dropdown.spec.js
+++ b/tests/unit/Dropdown.spec.js
@@ -164,16 +164,6 @@ describe('Toggling Dropdown', () => {
 		expect(spy).toHaveBeenCalled()
 	})
 
-	it('will open the dropdown and emit the search:focus event from onSearchFocus', () => {
-		spy = vi.spyOn(VueSelect.methods, 'onSearchFocus')
-		const Select = selectWithProps()
-
-		Select.vm.onSearchFocus()
-
-		expect(Select.vm.open).toEqual(true)
-		expect(spy).toHaveBeenCalled()
-	})
-
 	it('will close the dropdown on escape, if search is empty', () => {
 		const Select = selectWithProps()
 

--- a/tests/unit/TypeAhead.spec.js
+++ b/tests/unit/TypeAhead.spec.js
@@ -55,7 +55,7 @@ describe('Moving the Typeahead Pointer', () => {
 			},
 		})
 
-		Select.get('input').trigger('focus')
+		Select.vm.open = true
 		await nextTick()
 
 		expect(Select.vm.typeAheadPointer).toEqual(2)
@@ -74,7 +74,7 @@ describe('Moving the Typeahead Pointer', () => {
 			},
 		})
 
-		Select.get('input').trigger('focus')
+		Select.vm.open = true
 		await nextTick()
 
 		expect(Select.vm.typeAheadPointer).toEqual(2)


### PR DESCRIPTION
## Summary

Fixes two WCAG findings on the combobox reported against the use management "New Account" dialog (nextcloud-gmbh/customer-feature-requests#1587).

- **WCAG 3.2.1** - tabbing into the search input used to auto-open the dropdown, which jumps the screen reader into the listbox and announces an option before the field label. Users never hear which field they're in. Dropped the focus side-effect; Space/enter/down arrow still open the dropdown, clicks still work.
- **WCAG 4.1.2** - the chevron button exposed a useless "options list" accessible name via `aria-labelledby`. It's `tabindex="-1"` and the combobox input already exposes the open state, so it's purely decorative. Marked it `aria-hidden="true"` and dropped remaining aria tags. Mouse users still get the click target.

## Behavior changes

Worth a minor bump, not a patch:

- Code relying on "focus opens the dropdown" as a side-effect needs to open it explicitly or use a keyboard/click gesture.
- Tests querying `aria-labelledby`/`aria-controls`/`aria-expanded` on the button will break.

No props, events, or methods changed.

## Follow-ups

Once released:

1. `nextcloud-vue`: migrate `NcSelect` on `main` from upstream `vue-select` back to `@nextcloud/vue-select`, bump to this version
2. `server`: bump `@nextcloud/vue`
