### PR TITLE
chore: prepare v4.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [4.1.0](https://github.com/nextcloud-libraries/vue-select/compare/v4.0.0...v4.1.0) (2026-04-16)
 
 ### 🐛 Fixed bugs
 * fix(a11y): do not auto-open the dropdown on search input focus (WCAG 3.2.1 *On Focus*). Keyboard users still open via Space/Enter/ArrowDown/ArrowUp; mouse users still open by clicking.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue-select",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue-select",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "devDependencies": {
         "@nextcloud/eslint-config": "^9.0.0-rc.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue-select",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Everything you wish the HTML <select> element could do, wrapped up into a lightweight, extensible Vue component.",
   "homepage": "https://github.com/nextcloud-libraries/vue-select",
   "repository": {


### PR DESCRIPTION
## [4.1.0](https://github.com/nextcloud-libraries/vue-select/compare/v4.0.0...v4.1.0) (2026-04-16)

### 🐛 Fixed bugs
* fix(a11y): do not auto-open the dropdown on search input focus (WCAG 3.2.1 *On Focus*). Keyboard users still open via Space/Enter/ArrowDown/ArrowUp; mouse users still open by clicking. [\#73](https://github.com/nextcloud-libraries/vue-select/pull/73) \([pringelmann](https://github.com/pringelmann)\)
* fix(a11y): hide the decorative open-indicator button from the accessibility tree (`aria-hidden="true"`, no `aria-labelledby`/`aria-controls`/`aria-expanded`). WCAG 4.1.2 *Name, Role, Value*. [\#73](https://github.com/nextcloud-libraries/vue-select/pull/73) \([pringelmann](https://github.com/pringelmann)\)

### ⚠️ Behavior changes
* Focusing the combobox no longer opens the dropdown. Consumers that relied on this side-effect should open the dropdown explicitly (e.g. via `ref.open = true`) or migrate to a keyboard/click gesture.
* The open-indicator button no longer exposes its listbox state to assistive technology. Any code querying those ARIA attributes on the button will need to update.
