### PR TITLE
[main] ci: update all workflow templates from organization template repository

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -6,12 +6,14 @@
 # SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
 
-name: Node
+# TODO: Remove this after a grace period of 6 months to give everyone the chance to switch to the new workflow name
+# TODO: To be removed end of 2026.
+name: No-op please switch to npm-build.yml
 
 on: pull_request
 
 permissions:
-  contents: read
+  contents: none
 
 concurrency:
   group: node-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ steps.versions.outputs.node-version }}
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org
 
       - name: Set up npm


### PR DESCRIPTION
Automated update of all workflow templates from https://github.com/nextcloud-libraries/.github triggered by nextcloud-command